### PR TITLE
add: 管理者ログイン画面(ssessions#new)を追加

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -3,7 +3,7 @@
 class Admin::SessionsController < Devise::SessionsController
 
   def after_sign_in_path_for(resource)
-    admin_orders_path 
+    admin_root_path 
   end
 
   def after_sign_out_path_for(resource)

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -2,5 +2,5 @@ class Admin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :validatable
 end

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,25 +1,18 @@
-<h2>Log in</h2>
+<h2>管理者ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :email , "メールアドレス" %><br />
+    <%= f.email_field :email, placeholder: "sample@example.com",autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :password , "パスワード" %><br />
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
管理者のログイン画面（`sessions#new`）を作成しました。  
ログインフォームにはメールアドレス・パスワード・ログインボタンを実装済みです。

また、`app/models/admin.rb` の Devise モジュールから `:rememberable` を削除しました。
ログイン状態保持機能は使用しないためです。