### PR TITLE
add: 管理者用会員情報の編集フォーム実装

### DIFF
--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -1,0 +1,51 @@
+<h2><%= @customer.last_name %><%= @customer.first_name %>さんの会員情報編集</h2>
+
+<%= form_with(model: [:admin, @customer], local: true) do |f| %>
+  <div>
+    <p>会員ID <%= @customer.id %></p>
+  </div>
+
+  <div>
+    <%= f.label :last_name, "氏名" %>
+    <%= f.text_field :last_name %>
+    <%= f.text_field :first_name %>
+  </div>
+
+  <div>
+    <%= f.label :last_name_kana, "フリガナ" %>
+    <%= f.text_field :last_name_kana %>
+    <%= f.text_field :first_name_kana %>
+  </div>
+
+  <div>
+    <%= f.label :postal_code, "郵便番号" %>
+    <%= f.text_field :postal_code %>
+  </div>
+
+  <div>
+    <%= f.label :address, "住所" %>
+    <%= f.text_field :address %>
+  </div>
+
+  <div>
+    <%= f.label :telephone_number, "電話番号" %>
+    <%= f.text_field :telephone_number %>
+  </div>
+
+  <div>
+    <%= f.label :email, "メールアドレス" %>
+    <%= f.email_field :email %>
+  </div>
+
+  <div>
+    <%= f.label :is_active, "会員ステータス" %><br>
+    <%= f.radio_button :is_active, true %>
+    <%= f.label :is_active_true, "有効" %>
+    <%= f.radio_button :is_active, false %>
+    <%= f.label :is_active_false, "退会" %>
+  </div>
+
+  <div>
+    <%= f.submit "変更を保存", class: "btn btn-success" %>
+  </div>
+<% end %>


### PR DESCRIPTION
- `admin/customers#edit` にて編集フォームを実装しました。
- `is_active` のラジオボタンも導入済みですが、ステータス反映の確認は `show` 実装後に行う予定です。
