### PR TITLE
add: 管理者用会員詳細画面(show)を実装

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -3,6 +3,10 @@ class Admin::CustomersController < ApplicationController
     @customer = Customer.find(params[:id])
   end
 
+  def show
+    @customer = Customer.find(params[:id])
+  end
+
   def update
     @customer = Customer.find(params[:id])
     if @customer.update(customer_params)

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,0 +1,45 @@
+<h2><%= @customer.last_name %><%= @customer.first_name %>さんの会員詳細</h2>
+
+<table>
+  <tr>
+    <th>会員ID</th>
+    <td><%= @customer.id %></td>
+  </tr>
+  <tr>
+    <th>氏名</th>
+    <td><%= @customer.last_name %> <%= @customer.first_name %></td>
+  </tr>
+  <tr>
+    <th>フリガナ</th>
+    <td><%= @customer.last_name_kana %> <%= @customer.first_name_kana %></td>
+  </tr>
+  <tr>
+    <th>郵便番号</th>
+    <td><%= @customer.postal_code %></td>
+  </tr>
+  <tr>
+    <th>住所</th>
+    <td><%= @customer.address %></td>
+  </tr>
+  <tr>
+    <th>電話番号</th>
+    <td><%= @customer.telephone_number %></td>
+  </tr>
+  <tr>
+    <th>メールアドレス</th>
+    <td><%= @customer.email %></td>
+  </tr>
+  <tr>
+    <th>会員ステータス</th>
+    <td><%= @customer.is_active ? "有効" : "退会" %></td>
+  </tr>
+</table>
+
+<div class="actions">
+  <%= link_to "編集する", edit_admin_customer_path(@customer), class: "btn btn-success" %>
+</div>
+
+<!--
+  管理者UI flow図の９ページには注文履歴一覧を見るボタンがありますが、遷移先の１２ページに「※顧客ごとの
+  注文履歴は必須機能ではないため、このページは必須ではありません」との記載あるため、ボタン自体を実装していません。
+-->


### PR DESCRIPTION

- `admin/customers#show` にて、管理者用の会員詳細画面を実装しました。
- 会員ステータスの `is_active` はラジオボタンで表示し、反映動作も確認済みです。
- 管理者UIフロー図9ページに「注文履歴一覧を見る」ボタンの案がありますが、遷移先の12ページには  
  「※顧客ごとの注文履歴は必須機能ではないため、このページは必須ではありません」と記載があるため、  
   本実装ではボタン自体を含めていません。