### PR TITLE
add: 管理者用会員一覧(index)を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem "enum_help"
+gem 'kaminari', '~> 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.12.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -327,6 +339,7 @@ DEPENDENCIES
   enum_help
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
+  kaminari (~> 1.2.1)
   listen (~> 3.3)
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,4 +1,9 @@
 class Admin::CustomersController < ApplicationController
+  def index
+    @customers = Customer.page(params[:page]).per(10)
+  end
+  
+  
   def edit
     @customer = Customer.find(params[:id])
   end

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,0 +1,36 @@
+<h2>会員一覧</h2>
+
+<table>
+    <thead>
+        <tr>
+          <th>会員ID</th>
+          <th style="text-decoration: underline;">氏名</th>
+          <th>メールアドレス</th>
+          <th>ステータス</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @customers.each do |customer| %>
+          <tr>
+            <td><%= customer.id %></td>
+            <td>
+              <%= link_to "#{customer.last_name}#{customer.first_name}", admin_customer_path(customer) , style: "text-decoration: underline;" %>
+            </td>
+            <td><%= customer.email %></td>
+            <td>
+               <% if customer.is_active %>
+                 <span style="color: green;">有効</span>
+               <% else %>
+                 <span style="color: gray;">退会</span>
+               <% end %>
+            </td>
+          </tr>
+        <% end %>
+    </tbody>
+</table>
+<div>
+    <%= paginate @customers %>
+</div>
+
+<%# TODO: 最終リリース時には testuser を削除すること %>
+<%# Customer.where("email LIKE ?", "testuser%@example.com").destroy_all %>


### PR DESCRIPTION
### 管理者用 会員一覧画面の実装

- `admin/customers#index` にて、管理者用の会員一覧画面を実装しました。
- ページネーション機能を追加するため、`kaminari` を導入しました。
  - `Gemfile` に追加済みです。**merge後は各自 `bundle install` をお願いします。**

### テストデータについて

- ページネーションの動作確認のため、`testuser` を12件作成しました。
  - 内容：`テスト姓1〜12`、`testuser1〜12@example.com` など。
  - 本番環境には含めません。
  - **全実装完了後に削除予定**です。

### その他

- 表示件数は1ページあたり10件に設定しています。
- `@customers = Customer.page(params[:page]).per(10)` を `index` アクションで使用しています。