### PR TITLE
add: admin/genres#index・create アクションと一覧＋登録フォームを実装

### DIFF
--- a/app/assets/stylesheets/admin/genres.scss
+++ b/app/assets/stylesheets/admin/genres.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/genres controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,0 +1,22 @@
+class Admin::GenresController < ApplicationController
+  def index 
+    @genre = Genre.new
+    @genres = Genre.all
+  end
+
+  def create
+    @genre = Genre.new(genre_params)
+    if @genre.save
+      redirect_to admin_genres_path, notice: "ジャンルを追加しました"
+    else 
+      @genres = Genre.all
+      render :index
+    end
+  end
+
+  private
+
+  def genre_params
+    params.require(:genre).permit(:name)
+  end
+end

--- a/app/helpers/admin/genres_helper.rb
+++ b/app/helpers/admin/genres_helper.rb
@@ -1,0 +1,2 @@
+module Admin::GenresHelper
+end

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,0 +1,31 @@
+<h2>ジャンル一覧・追加</h2>
+
+<%= form_with model: @genre, url: admin_genres_path, local: true do |f| %>
+  <div>
+    <%= f.label :name, "ジャンル名" %>
+    <%= f.text_field :name, placeholder: "ジャンル名" %>
+    <%= f.submit "新規登録", class: "btn btn-success" %>
+  </div>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>ジャンル</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @genres.each do |genre| %>
+      <tr>
+        <td><%= genre.name %></td>
+        <td>
+          <%= link_to "編集する", edit_admin_genre_path(genre), class: "btn btn-success" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+
+  

--- a/test/controllers/admin/genres_controller_test.rb
+++ b/test/controllers/admin/genres_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::GenresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
管理者用ジャンル一覧・新規登録機能を実装しました。

## 対応内容
- `admin/genres#index` にてジャンルの一覧表示を実装
- 一覧ページに新規ジャンル登録フォームを統合
- 一時的にテストジャンルデータを手動登録して動作確認済