### PR TITLE
Add: 商品詳細画面の実装（admin/items#show）

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -7,11 +7,15 @@ class Admin::ItemsController < Admin::BaseController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to admin_items_path, notice: "商品を登録しました"
+      redirect_to admin_item_path(@item), notice: "商品を登録しました"
     else
       @genres = Genre.all
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,9 @@
 class Item < ApplicationRecord
+  has_one_attached :image
+  belongs_to :genre
+
+  def price_with_tax
+    (price_without_tax * 1.1).floor
+  end
+
 end

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -33,6 +33,6 @@
   </div>
 
   <div>
-    <%= f.submit "新規登録", class: "btn btn-success" %>
+    <%= f.submit "新規登録" %>
   </div>
 <% end %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,0 +1,30 @@
+<h2>商品詳細</h2>
+
+<div>
+  <div>
+    <% if @item.image.attached? %>
+      <%= image_tag @item.image, width: 300 %>
+    <% else %>
+      <%= image_tag 'no_image.jpg', width: 300 %>
+    <% end %>
+  </div>
+
+  <div>
+    <p>商品名<%= @item.name %></p>
+    <p>商品説明<%= @item.introduction %></p>
+    <p>ジャンル<%= @item.genre.name %></p>
+    <p>税込価格</p><br>
+    <p>（税抜価格)<%= number_to_currency(@item.price_with_tax) %>（<%= number_to_currency(@item.price_without_tax) %>）</p>
+
+    <p>
+      販売ステータス
+      <% if @item.is_active %>
+        <span style="color: green;">販売中</span>
+      <% else %>
+        <span style="color: gray;">販売停止中</span>
+      <% end %>
+    </p>
+
+    <%= link_to '編集する', edit_admin_item_path(@item) %>
+  </div>
+</div>

--- a/app/views/layouts/admin/_header.html.erb
+++ b/app/views/layouts/admin/_header.html.erb
@@ -1,15 +1,15 @@
 <header>
-  <nav class="admin-nav">
-    <div class="btn btn-outline-success">
+  <nav>
+    <div>
       <%= link_to "LOGO", admin_root_path %>
     </div>
 
     <ul class="nav-links">
-      <li class="btn btn-outline-info"><%= link_to "商品一覧", admin_items_path %></li>
-      <li class="btn btn-outline-info"><%= link_to "会員一覧", admin_customers_path %></li>
-      <li class="btn btn-outline-info"><%= link_to "注文履歴一覧", admin_root_path %></li>
-      <li class="btn btn-outline-info"><%= link_to "ジャンル一覧", admin_genres_path %></li>
-      <li class="btn btn-outline-info"><%= link_to "ログアウト", destroy_admin_session_path, method: :delete %></li>
+      <li><%= link_to "商品一覧", admin_items_path %></li>
+      <li><%= link_to "会員一覧", admin_customers_path %></li>
+      <li><%= link_to "注文履歴一覧", admin_root_path %></li>
+      <li><%= link_to "ジャンル一覧", admin_genres_path %></li>
+      <li><%= link_to "ログアウト", destroy_admin_session_path, method: :delete %></li>
     </ul>
 
   </nav>


### PR DESCRIPTION
## 概要
管理者が商品詳細を確認できる画面を作成しました。

## 実装内容
- `admin/items#show` アクションを追加
- 商品情報（商品名、商品説明、ジャンル、価格、販売ステータス、商品画像）を表示
- `price_with_tax` メソッドをモデルに定義し、税込価格を表示
- 商品画像がない場合、仮画像を表示

