### PR TITLE
Add: ジャンル詳細画面の実装（admin/genres#edit）

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -13,6 +13,20 @@ class Admin::GenresController < Admin::BaseController
       render :index
     end
   end
+  
+
+    def edit 
+      @genre = Genre.find(params[:id])
+    end
+
+    def update
+      @genre = Genre.find(params[:id])
+      if @genre.update(genre_params)
+        redirect_to admin_genres_path, notice: "ジャンルを更新しました。"
+      else
+        render :edit
+      end
+    end
 
   private
 

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -35,8 +35,8 @@
   </tr>
 </table>
 
-<div class="actions">
-  <%= link_to "編集する", edit_admin_customer_path(@customer), class: "btn btn-success" %>
+<div>
+  <%= link_to "編集する", edit_admin_customer_path(@customer) %>
 </div>
 
 <!--

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,0 +1,12 @@
+<h2>ジャンル編集</h2>
+
+<%= form_with model: @genre, url: admin_genre_path(@genre), local: true do |f| %>
+  <div>
+    <%= f.label :name, "ジャンル名" %><br>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.submit "変更を保存" %>
+  </div>
+<% end %>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -4,7 +4,7 @@
   <div>
     <%= f.label :name, "ジャンル名" %>
     <%= f.text_field :name, placeholder: "ジャンル名" %>
-    <%= f.submit "新規登録", class: "btn btn-success" %>
+    <%= f.submit "新規登録" %>
   </div>
 <% end %>
 
@@ -20,7 +20,7 @@
       <tr>
         <td><%= genre.name %></td>
         <td>
-          <%= link_to "編集する", edit_admin_genre_path(genre), class: "btn btn-success" %>
+          <%= link_to "編集する", edit_admin_genre_path(genre) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -2,11 +2,7 @@
 
 <div>
   <div>
-    <% if @item.image.attached? %>
-      <%= image_tag @item.image, width: 300 %>
-    <% else %>
-      <%= image_tag 'no_image.jpg', width: 300 %>
-    <% end %>
+    <%= image_tag get_image(@item), width: 300 %>
   </div>
 
   <div>
@@ -14,7 +10,7 @@
     <p>商品説明<%= @item.introduction %></p>
     <p>ジャンル<%= @item.genre.name %></p>
     <p>税込価格</p><br>
-    <p>（税抜価格)<%= number_to_currency(@item.price_with_tax) %>（<%= number_to_currency(@item.price_without_tax) %>）</p>
+    <p>（税抜価格)¥<%= number_with_delimiter(@item.price_with_tax) %>（<%= number_to_currency(@item.price_without_tax) %>）</p>
 
     <p>
       販売ステータス


### PR DESCRIPTION
##  変更内容

- 管理者用ジャンル編集画面の作成（`admin/genres#edit`）
- フォームに既存ジャンル名の表示と編集機能を追加
- 更新ボタンを押すとジャンル情報が更新されるように実装


