### PR TITLE
Add: 商品一覧画面の実装（admin/genres#index）

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,4 +1,12 @@
 class Admin::ItemsController < Admin::BaseController
+  def index
+    @items = Item.page(params[:page]).per(10)
+  end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def new
     @item = Item.new
     @genres = Genre.all
@@ -14,9 +22,6 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
-  def show
-    @item = Item.find(params[:id])
-  end
 
   private
 

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -14,7 +14,7 @@
           <tr>
             <td><%= customer.id %></td>
             <td>
-              <%= link_to "#{customer.last_name}#{customer.first_name}", admin_customer_path(customer) , style: "text-decoration: underline;" %>
+              <%= link_to "#{customer.last_name}#{customer.first_name}", admin_customer_path(customer) %>
             </td>
             <td><%= customer.email %></td>
             <td>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,34 @@
+<h2>商品一覧</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>商品ID</th>
+      <th>商品名</th>
+      <th>税抜価格</th>
+      <th>ジャンル</th>
+      <th>ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @items.each do |item| %>
+      <tr>
+        <td><%= item.id %></td>
+        <td><%= link_to item.name, admin_item_path(item) %></td>
+        <td><%= number_with_delimiter(item.price_without_tax) %></td>
+        <td><%= item.genre.name, if item.genre.present? %></td>
+        <td>
+          <% if item.is_active %>
+            <span style="color: green;">販売中</span>
+          <% else %>
+            <span style="color: gray;">販売停止中</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div>
+  <%= paginate @items %>
+</div>


### PR DESCRIPTION
##変更内容
- 管理者用商品一覧画面の作成（admin/items#index）
- フォームに商品ID、商品名、税抜価格、ジャンル、ステータスの表示を追加
- 商品名を押すと商品詳細画面へと遷移されるように実装
- ヘッダーの商品一覧ボタンが遷移できるようになりました。