### PR TITLE
Add: 商品編集画面の実装（admin/items#edit）

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -22,6 +22,21 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
+    def edit
+      @item = Item.find(params[:id])
+      @genres = Genre.all
+    end
+    
+    def update
+      @item = Item.find(params[:id])
+      if @item.update(item_params)
+        redirect_to admin_item_path(@item), notice: "商品情報を更新しました"
+      else
+        @genres = Genre.all
+        render :edit
+      end
+    end
+
 
   private
 

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,40 @@
+<h2>商品編集</h2>
+
+<%= form_with model: @item, url: admin_item_path(@item), local: true do |f| %>
+
+  <div>
+    <%= f.label :image, "商品画像" %>
+    <%= f.file_field :image , accept: "image/*" %>
+  </div>
+
+  <div>
+    <%= f.label :name, "商品名" %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :introduction, "商品説明" %>
+    <%= f.text_area :introduction, rows: 5 %>
+  </div>
+
+  <div>
+    <%= f.label :genre_id, "ジャンル" %>
+    <%= f.collection_select :genre_id, @genres, :id, :name %>
+  </div>
+
+  <div>
+    <%= f.label :price_without_tax, "税抜価格" %>
+    <%= f.number_field :price_without_tax %> 円
+  </div>
+
+  <div>
+    <%= f.label :is_active, "販売ステータス" %>
+    <%= f.radio_button :is_active, true %> <%= f.label :is_active_true, "販売中" %>
+    <%= f.radio_button :is_active, false %> <%= f.label :is_active_false, "販売停止中" %>
+  </div>
+
+  <div>
+    <%= f.submit "変更を保存" %>
+  </div>
+
+<% end %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -16,7 +16,7 @@
         <td><%= item.id %></td>
         <td><%= link_to item.name, admin_item_path(item) %></td>
         <td><%= number_with_delimiter(item.price_without_tax) %></td>
-        <td><%= item.genre.name, if item.genre.present? %></td>
+        <td><%= item.genre.name if item.genre.present? %></td>
         <td>
           <% if item.is_active %>
             <span style="color: green;">販売中</span>


### PR DESCRIPTION
##変更内容
-管理者用商品編集画面の作成（admin/items#edit）
-フォームに商品画像、商品名、商品説明、既存ジャンル名の表示、税抜価格、販売ステータスの編集機能を追加
-変更を保存ボタンを押すと商品編集が更新されるように実装
-遷移先は商品詳細画面に設定