### PR TITLE
Add: 管理者用注文詳細画面の実装（admin/orders#show）

### DIFF
--- a/app/assets/stylesheets/admin/order_details.scss
+++ b/app/assets/stylesheets/admin/order_details.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/order_details controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,0 +1,17 @@
+class Admin::OrderDetailsController < Admin::BaseController
+  def update
+    @order_detail = OrderDetail.find(params[:id])
+    if @order_detail.update(order_detail_params)
+      flash[:notice] = "製作ステータスを更新しました"
+    else
+      flash[:alert] = "更新に失敗しました"
+    end
+    redirect_to admin_order_path(@order_detail.order_id)
+  end
+
+  private
+
+  def order_detail_params
+    params.require(:order_detail).permit(:production_status)
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,3 +1,21 @@
-class Admin::OrdersController < ApplicationController
-  
+class Admin::OrdersController < Admin::BaseController
+  def show
+    @order = Order.find(params[:id])
+  end
+
+  def update
+    @order = Order.find(params[:id])
+    if @order.update(order_params)
+      flash[:notice] = "注文ステータスを更新しました"
+    else
+      flash[:alert] = "更新に失敗しました"
+    end
+    redirect_to admin_order_path(@order)
+  end
+
+  private
+
+  def order_params
+    params.require(:order).permit(:status)
+  end
 end

--- a/app/helpers/admin/order_details_helper.rb
+++ b/app/helpers/admin/order_details_helper.rb
@@ -1,0 +1,2 @@
+module Admin::OrderDetailsHelper
+end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,0 +1,45 @@
+<h2>注文履歴詳細</h2>
+
+<p>
+  購入者：<%= link_to "#{@order.customer.last_name} #{@order.customer.first_name}", admin_customer_path(@order.customer.id) %><br>
+  注文日：<%= @order.created_at.to_date %><br>
+  配送先：<%= @order.postal_code %> <%= @order.address %> <%= @order.name %><br>
+  支払方法：<%= @order.payment_method_i18n %><br>
+</p>
+
+<%= form_with model: @order, url: admin_order_path(@order), method: :patch, local: true do |f| %>
+  注文ステータス：
+  <%= f.select :status, Order.statuses.keys.map { |k| [k.humanize, k] }, selected: @order.status %>
+  <%= f.submit "更新" %>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>商品名</th>
+      <th>単価（税込）</th>
+      <th>数量</th>
+      <th>小計</th>
+      <th>製作ステータス</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @order.order_details.each do |detail| %>
+      <tr>
+        <td><%= detail.item.name %></td>
+        <td><%= number_with_delimiter(detail.price_with_tax) %></td>
+        <td><%= detail.amount %></td>
+        <td><%= number_with_delimiter(detail.price_with_tax * detail.amount) %></td>
+        <td>
+          <%= form_with model: detail, url: admin_order_detail_path(detail), method: :patch, local: true do |f| %>
+          <%= f.select :production_status, OrderDetail.production_statuses.keys.map { |k| [I18n.t("enums.order_detail.production_status.#{k}"), k] }, selected: detail.production_status %>
+        </td>
+        <td>    
+            <%= f.submit "更新" %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -13,6 +13,14 @@
 
   <body>
     <%= render 'layouts/admin/header' %>
+    <% if flash[:notice] %>
+      <div><%= flash[:notice] %></div>
+    <% end %>
+
+    <% if flash[:alert] %>
+      <div><%= flash[:alert] %></div>
+    <% end %>
+
     <main>
       <%= yield %>
     </main>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,13 @@ ja:
           製作中: "製作中"
           発送準備中: "発送準備中"
           発送済み: "発送済み"
+  enums:
+    order_detail:
+      production_status:
+        not_startable: "製作不可"
+        waiting: "製作待ち"
+        in_production: "製作中"
+        finished: "製作完了"
   date:
     abbr_day_names:
     - 日

--- a/test/controllers/admin/order_details_controller_test.rb
+++ b/test/controllers/admin/order_details_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::OrderDetailsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 管理者用 注文履歴詳細ページの実装・改善

### ✅ 主な変更点

- `Admin::OrdersController` に `show` および `update` アクションを追加
- `Admin::OrderDetailsController` に `update` アクションを追加（製作ステータス更新用）
- 注文詳細ページ（`admin/orders/show.html.erb`）の作成
  - 購入者情報／注文日／配送先などを表示
  - 注文ステータス・製作ステータスの更新フォームを追加
- enumのi18n（`ja.yml`）対応（order_detail.production_status）
- Flashメッセージの表示機能を `layouts/admin.html.erb` に追加

### ✅ 補足情報

- 製作ステータスや注文ステータスは `enum` として扱い、i18nで日本語変換
- `number_with_delimiter` で金額表示を見やすく整形
- flash[:notice] / flash[:alert] の表示で操作結果がユーザーに伝わるように改善
