### PR TITLE
Add: 日本語バリデーションエラーメッセージをja.ymlに追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,12 @@
 class Item < ApplicationRecord
   has_one_attached :image
-  belongs_to :genre
+  belongs_to :genre, optional: true
   has_many :order_details, dependent: :destroy
+
+  validates :name, presence: true
+  validates :introduction, presence: true
+  validates :genre_id, presence: true
+  validates :price_without_tax, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
   def price_with_tax
     (price_without_tax * 1.1).floor

--- a/app/views/admin/shared/_error_messages.html.erb
+++ b/app/views/admin/shared/_error_messages.html.erb
@@ -1,10 +1,7 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+     <%= I18n.t("errors.messages.not_saved", count: resource.errors.count) %>
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -21,6 +21,10 @@
       <div><%= flash[:alert] %></div>
     <% end %>
 
+    <%= render "admin/shared/error_messages", resource: @item if @item.present? %>
+    <%= render "admin/shared/error_messages", resource: @customer if @customer.present?%>
+    <%= render "admin/shared/error_messages", resource: @genre if @genre.present?%>
+
     <main>
       <%= yield %>
     </main>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,9 +1,9 @@
 ja:
   enums:
-    order:
-      payment_method:
-        credit_card: "クレジットカード"
-        transfer: "銀行振込"
+      order:
+        payment_method:
+          credit_card: "クレジットカード"
+          transfer: "銀行振込"
   activerecord:
     errors:
       messages:
@@ -11,6 +11,27 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+  activerecord:
+   models:
+      genre: ジャンル
+   attributes:
+     genre: 
+       name: ジャンル名
+     customer:
+       last_name: 姓
+       first_name: 名
+       last_name_kana: 姓（カナ）
+       first_name_kana: 名（カナ）
+       email: メールアドレス
+       postal_code: 郵便番号
+       address: 住所
+       telephone_number: 電話番号
+     item:
+       name: 商品名
+       introduction: 商品説明
+       price_without_tax: 税抜価格
+       genre: ジャンル
+       genre_id: ジャンル
   attributes:
       order:
         status:
@@ -129,6 +150,7 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      not_saved: "%{count}件のエラーがあります。保存できませんでした。"
     template:
       body: 次の項目を確認してください
       header: "%{model}に%{count}個のエラーが発生しました"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
+Admin.create!(
+  email: 'admin@example.com',
+  password: 'password',  
+  password_confirmation: 'password'
+)
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
## 概要

- ja.ymlに各種バリデーションエラーメッセージ（日本語）の追記・修正
  - 支払い方法・ジャンル名・商品名などの入力エラー時に日本語で表示されるよう対応
- db/seeds.rbにアドミン（管理者）アカウントを追加
  - グループ開発・レビュー用
  - ID: admin@example.com / PASS: password

