### PR TITLE
Fix: 管理者用製作ステータスと注文ステータスの連動操作の訂正

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,11 +1,17 @@
 class Admin::OrderDetailsController < Admin::BaseController
   def update
     @order_detail = OrderDetail.find(params[:id])
-    if @order_detail.update(order_detail_params)
-      flash[:notice] = "製作ステータスを更新しました"
-    else
-      flash[:alert] = "更新に失敗しました"
+    @order_detail.update(production_status: params[:order_detail][:production_status])
+    order = @order_detail.order
+    if params[:order_detail][:production_status] == "in_production"
+      order.update(status:"in_production")
     end
+    
+    if is_all_order_details_finished(order)
+       order.update(status: "preparing_for_shipment")
+    end
+    
+    flash[:notice] = "更新に成功しました。"
     redirect_to admin_order_path(@order_detail.order_id)
   end
 
@@ -13,5 +19,14 @@ class Admin::OrderDetailsController < Admin::BaseController
 
   def order_detail_params
     params.require(:order_detail).permit(:production_status)
+  end
+
+  def is_all_order_details_finished(order)
+    order.order_details.each do |order_detail|
+      if order_detail.production_status != 'finished'
+        return false
+      end
+    end
+     return true
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -6,6 +6,18 @@ class Admin::OrdersController < Admin::BaseController
   def update
     @order = Order.find(params[:id])
     if @order.update(order_params)
+      if @order.saved_change_to_status?
+        case @order.status.to_sym
+        when :payment_confirmed
+          @order.order_details.each do |detail|
+            detail.update(production_status: :waiting)
+          end
+        when :payment_pending
+          @order.order_details.each do |detail|
+            detail.update(production_status: :not_startable)
+          end
+        end
+      end
       flash[:notice] = "注文ステータスを更新しました"
     else
       flash[:alert] = "更新に失敗しました"

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,13 +1,13 @@
 class Order < ApplicationRecord
   belongs_to :customer
-  has_many :order_details
+  has_many :order_details, dependent: :destroy
 
   enum payment_method: { credit_card: 0, transfer: 1 }
   enum status: {
-    入金待ち: 0,
-    入金確認: 1,
-    製作中: 2,
-    発送準備中: 3,
-    発送済み: 4
-  }
+    payment_pending: 0,
+    payment_confirmed: 1,
+    in_production: 2,
+    preparing_for_shipment: 3,
+    shipped: 4
+}
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,12 @@ ja:
         payment_method:
           credit_card: "クレジットカード"
           transfer: "銀行振込"
+        status:
+          payment_pending: "入金待ち"
+          payment_confirmed: "入金確認"
+          in_production: "製作中"
+          preparing_for_shipment: "発送準備中"
+          shipped: "発送済み"  
       order_detail:
         production_status:
           not_startable: "製作不可"
@@ -37,13 +43,6 @@ ja:
         price_without_tax: 税抜価格
         genre: ジャンル
         genre_id: ジャンル
-      order:
-        status:
-          入金待ち: "入金待ち"
-          入金確認: "入金確認"
-          製作中: "製作中"
-          発送準備中: "発送準備中"
-          発送済み: "発送済み"
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
## 🔧 修正内容

管理者側で製作ステータスと注文ステータスが正しく連動していなかったため、以下のロジックに基づいて処理を修正しました。

## 実現する仕様（連動ルール）

- 注文ステータスが `入金確認（payment_confirmed）` になったとき  
　→ 製作ステータスを全て `製作待ち（waiting）` に更新

- 製作ステータスが1件でも `製作中（in_production）` になったとき  
　→ 注文ステータスを `製作中（in_production）` に更新

- 製作ステータスが全て `製作完了（finished）` になったとき  
　→ 注文ステータスを `発送準備中（preparing_for_shipment）` に更新

- 注文ステータスが `発送済み（shipped）` に更新された場合  
　→ そのままステータスを保持

