### PR TITLE
Fix: 管理者用注文履歴詳細画面のステータス表記の日本語化の訂正

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,4 +1,4 @@
 class Admin::BaseController < ApplicationController
   layout 'admin'
-  # before_action :authenticate_admin!
+  before_action :authenticate_admin!
 end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -40,7 +40,7 @@
         <div class="u-field">
           <%= form_with model: @order, url: admin_order_path(@order), method: :patch, local: true do |f| %>
             <div class="u-d-f u-gap-30">
-              <%= f.select :status, Order.statuses.keys.map { |k| [k.humanize, k] }, selected: @order.status, class: "u-form-select" %>
+              <%= f.select :status, Order.statuses_i18n.invert, selected: @order.status, class: "u-form-select" %>
               <%= f.submit "更新", class: "u-btn opt-small-1 u-fw-b" %>
             </div>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
   # 管理者側のルーティング設定
   namespace :admin do
-    root to: "homes#top" # ← 編集する可能性あり
+    root to: "homes#top" 
 
     resources :items, only: [:index, :new, :create, :show, :edit, :update]
 


### PR DESCRIPTION
管理者側の注文履歴詳細画面にて、注文ステータスが英語で表示されていた不具合を修正しました。

原因は、enumのキーとja.ymlのキーが一致しておらず、`status_i18n`が正しく動作していなかったためです。

修正内容：
- Orderモデルのenum定義とja.ymlのキーを統一
- `f.select`のステータス選択肢において、日本語表記を参照するよう修正

これにより、管理画面での注文ステータスの表示と選択がすべて日本語で統一されました。